### PR TITLE
feat: EventEmittingService

### DIFF
--- a/src/builder-render.spec.ts
+++ b/src/builder-render.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+
+import { builderRender } from './builder-render.js';
+
+describe('builderRender', function () {
+  it('should render a builder with data', async function () {
+    const result = await builderRender({ value: 'test' });
+
+    expect(result).to.deep.equal({ value: 'test' });
+  });
+
+  it('should render a builder with a function', async function () {
+    const result = await builderRender({ value: () => 'test' });
+
+    expect(result).to.deep.equal({ value: 'test' });
+  });
+
+  it('should render a builder with a function and data', async function () {
+    const result = await builderRender({
+      value: () => 'test',
+      value2: 'test2',
+    });
+
+    expect(result).to.deep.equal({ value: 'test', value2: 'test2' });
+  });
+});

--- a/src/types/builder-options.ts
+++ b/src/types/builder-options.ts
@@ -3,7 +3,7 @@ import { ProviderFn } from './provider.js';
 type BuilderOption<T> = T | ProviderFn<T>;
 
 /**
- * At type that represents a set of options for a builder.
+ * A type that represents a set of options for a builder.
  * It iterates over the keys (type P) of the type T and allows for
  * each key to be either a value of type T[P] or a provider function
  * that returns a value of type T.

--- a/src/types/builder-options.ts
+++ b/src/types/builder-options.ts
@@ -2,6 +2,14 @@ import { ProviderFn } from './provider.js';
 
 type BuilderOption<T> = T | ProviderFn<T>;
 
+/**
+ * At type that represents a set of options for a builder.
+ * It iterates over the keys (type P) of the type T and allows for
+ * each key to be either a value of type T[P] or a provider function
+ * that returns a value of type T.
+ *
+ * @typeParam T - The type of the object intended to be built.
+ */
 export type BuilderOptions<T> = {
   [P in keyof T]?: BuilderOption<T[P]>;
 } & {

--- a/src/types/event-emitting-service.ts
+++ b/src/types/event-emitting-service.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type EventDefinition = Record<string, (...args: any) => any>;
+
+/**
+ * An interface to define specific events that can be emitted by a service.
+ * This ensures that the events are typed correctly.
+ *
+ * @typeParam T - The event definition.
+ * @example
+ * ```ts
+ * type MyEvents = {
+ *  'someEvent': (data: string) => void;
+ * };
+ *
+ * class MyService
+ *   extends EventEmitter
+ *   implements EventEmittingService<MyEvents> {
+ *  // ...
+ * }
+ * ```
+ */
+export interface EventEmittingService<T extends EventDefinition> {
+  on<E extends keyof T>(event: E, listener: T[E]): this;
+  emit<E extends keyof T>(event: E, ...args: Parameters<T[E]>): boolean;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './builder.js';
 export * from './builder-options.js';
 export * from './component.js';
+export * from './event-emitting-service.js';
 export * from './provider.js';


### PR DESCRIPTION
Shared interface for defining the events a Service emits using EventEmitter. Intended to reduce some boilerplate.

Also handled some chores in this PR
- Added tests for `builderRender`
- Added docs to `BuilderOptions`