### PR TITLE
fix(http): import paths and add type annotations

### DIFF
--- a/src/http/composite-headers-provider.ts
+++ b/src/http/composite-headers-provider.ts
@@ -1,10 +1,9 @@
-import { getComponent } from '@sektek/utility-belt';
-
 import {
   HeadersProvider,
   HeadersProviderComponent,
   HeadersProviderFn,
 } from './types/index.js';
+import { getComponent } from '../get-component.js';
 
 export type CompositeHeadersProviderOptions<T> = {
   providers: HeadersProviderComponent<T> | HeadersProviderComponent<T>[];
@@ -25,6 +24,9 @@ export class CompositeHeadersProvider<T> implements HeadersProvider<T> {
     await Promise.all(
       this.#providers.map(async provider => {
         const providerHeaders = await provider(arg);
+        if (!providerHeaders) {
+          return;
+        }
 
         if (providerHeaders instanceof Headers) {
           providerHeaders.forEach((value, name) => {

--- a/src/http/http-operator.spec.ts
+++ b/src/http/http-operator.spec.ts
@@ -220,7 +220,7 @@ describe('HttpOperator', function () {
       const operator = new HttpOperator<string>({
         url: 'http://test.local',
         method: 'POST',
-        bodySerializer: body => JSON.stringify({ key: body }),
+        bodySerializer: (body: string) => JSON.stringify({ key: body }),
       });
 
       const response = await operator.perform('value');

--- a/src/http/http-operator.ts
+++ b/src/http/http-operator.ts
@@ -1,10 +1,5 @@
 import { EventEmitter } from 'events';
 
-import { getComponent } from '../get-component.js';
-
-import { CompositeHeadersProvider } from './composite-headers-provider.js';
-import { contentTypeHeadersProvider } from './content-type-headers-provider.js';
-
 import {
   BodySerializerComponent,
   BodySerializerFn,
@@ -14,6 +9,9 @@ import {
   UrlProviderComponent,
   UrlProviderFn,
 } from './types/index.js';
+import { CompositeHeadersProvider } from './composite-headers-provider.js';
+import { contentTypeHeadersProvider } from './content-type-headers-provider.js';
+import { getComponent } from '../get-component.js';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 

--- a/src/http/http-optional-provider.spec.ts
+++ b/src/http/http-optional-provider.spec.ts
@@ -163,7 +163,7 @@ describe('HttpOptionalProvider', function () {
 
       const provider = new HttpOptionalProvider<unknown, void>({
         url,
-        responseDeserializer: async response => {
+        responseDeserializer: async (response: Response) => {
           const data = (await response.json()) as Record<string, unknown>;
           return { ...data, customField: 'customValue' };
         },

--- a/src/http/types/body-serializer.ts
+++ b/src/http/types/body-serializer.ts
@@ -1,4 +1,4 @@
-import { Component } from '@sektek/utility-belt';
+import { Component } from '../../types/index.js';
 
 // Having some typing issues with BodyInit and fetch
 // So I'm commenting out the types that are causing conflicts

--- a/src/http/types/headers-provider.ts
+++ b/src/http/types/headers-provider.ts
@@ -1,12 +1,16 @@
-import { Provider, ProviderComponent, ProviderFn } from '../../types/index.js';
+import {
+  OptionalProvider,
+  OptionalProviderComponent,
+  OptionalProviderFn,
+} from '../../types/index.js';
 import { HeadersInit } from 'undici-types';
 
-export type HeadersProviderFn<T = unknown> = ProviderFn<HeadersInit, T>;
+export type HeadersProviderFn<T = unknown> = OptionalProviderFn<HeadersInit, T>;
 
 export interface HeadersProvider<T = unknown>
-  extends Provider<HeadersInit, T> {}
+  extends OptionalProvider<HeadersInit, T> {}
 
-export type HeadersProviderComponent<T = unknown> = ProviderComponent<
+export type HeadersProviderComponent<T = unknown> = OptionalProviderComponent<
   HeadersInit,
   T
 >;

--- a/src/http/types/http-event-service-events.ts
+++ b/src/http/types/http-event-service-events.ts
@@ -1,4 +1,4 @@
-import { EventEmittingService } from '@sektek/utility-belt';
+import { EventEmittingService } from '../../types/index.js';
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 

--- a/src/http/types/response-deserializer.ts
+++ b/src/http/types/response-deserializer.ts
@@ -1,4 +1,4 @@
-import { Component } from '@sektek/utility-belt';
+import { Component } from '../../types/index.js';
 
 export type ResponseDeserializerFn<T> = (
   response: Response,


### PR DESCRIPTION
Correct import paths for consistency and add type annotations to `bodySerializer` and `responseDeserializer` functions to improve type safety.