### PR TITLE
fix: update provider interfaces

### DIFF
--- a/src/provider-wrapper.ts
+++ b/src/provider-wrapper.ts
@@ -19,7 +19,7 @@ export const wrapOptionalProvider = <R, T = void>(
   defaultValue?: R,
 ): ProviderFn<R, T> => {
   const providerFn: OptionalProviderFn<R, T> = getComponent(provider, 'get');
-  return async (arg?: T): Promise<R> => {
+  return async (arg: T): Promise<R> => {
     const result = await providerFn(arg);
     if (result === undefined && defaultValue === undefined) {
       throw new Error('Provider returned undefined');
@@ -73,7 +73,7 @@ export class ProviderWrapper<R, T = void> implements Provider<R, T> {
     return new ProviderWrapper<R, T>({ provider, defaultValue });
   }
 
-  async get(arg?: T): Promise<R> {
+  async get(arg: T): Promise<R> {
     let result = await this.#optionalProvider(arg);
     result ??= await this.#defaultValueProvider(arg);
 

--- a/src/time-sensitive-optional-provider.ts
+++ b/src/time-sensitive-optional-provider.ts
@@ -31,6 +31,9 @@ export class TimeSensitiveOptionalProvider<T, K = string> {
   }
 
   async get(key: K): Promise<T | undefined> {
-    return await Promise.race([this.#provider(key), this.#timeoutProvider()]);
+    return await Promise.race([
+      this.#provider(key),
+      this.#timeoutProvider(key),
+    ]);
   }
 }

--- a/src/time-sensitive-provider.ts
+++ b/src/time-sensitive-provider.ts
@@ -32,6 +32,9 @@ export class TimeSensitiveProvider<T, K = string> {
   }
 
   async get(key: K): Promise<T | undefined> {
-    return await Promise.race([this.#provider(key), this.#timeoutProvider()]);
+    return await Promise.race([
+      this.#provider(key),
+      this.#timeoutProvider(key),
+    ]);
   }
 }

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -13,11 +13,14 @@ import { Component } from './component.js';
  * @param T - The type of the argument passed to the provider.
  *            If not provided, the provider does not expect an argument.
  */
-export type ProviderFn<R, T = void> = (arg: T | void) => R | PromiseLike<R>;
+export type ProviderFn<R, T = unknown> = (arg: T) => R | PromiseLike<R>;
 
 /** An interface allowing for a class based provider */
-export interface Provider<R, T = void> {
+export interface Provider<R, T = unknown> {
   get: ProviderFn<R, T>;
 }
 
-export type ProviderComponent<R, T = void> = Component<Provider<R, T>, 'get'>;
+export type ProviderComponent<R, T = unknown> = Component<
+  Provider<R, T>,
+  'get'
+>;


### PR DESCRIPTION
Refactor provider interfaces to use `unknown` type for arguments, ensuring stricter type safety. Update related methods to require arguments, enhancing consistency across the codebase.