### PR TITLE
chore: dev tooling updates

### DIFF
--- a/.mocharc.min.cjs
+++ b/.mocharc.min.cjs
@@ -1,0 +1,7 @@
+const base = require('./.mocharc.cjs');
+
+module.exports = {
+  ...base,
+  reporter: 'dot',
+  color: false,
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "npx tsc -p tsconfig.build.json",
     "lint": "eslint . --cache",
     "test": "mocha",
+    "test:min": "mocha --config .mocharc.min.cjs",
     "test:cover": "c8 npm run test",
     "packages:update": "npm install --package-lock-only --workspaces=false",
     "release": "release-it --ci"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
@@ -20,6 +19,7 @@
     "noFallthroughCasesInSwitch": true,
     "strictPropertyInitialization": true,
     "esModuleInterop": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "types": ["@types/mocha"]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `test:min` npm script and `.mocharc.min.cjs` for dot-reporter, no-colour test output (for CLI/AI use)
- Adds `@types/mocha` to `tsconfig.json` types; removes unused `baseUrl`

## Test plan

- [ ] `npm -w libs/utility-belt run test:min` produces dot output with no colour
- [ ] `npm -w libs/utility-belt run build` compiles cleanly
- [ ] `npm -w libs/utility-belt test` still works with spec reporter