### PR TITLE
feat: replace Node events with eventemitter3 for browser compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "eventemitter3": "^5.0.4",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
         "undici-types": "^7.8.0"
@@ -4995,6 +4996,12 @@
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "release": "release-it --ci"
   },
   "dependencies": {
+    "eventemitter3": "^5.0.4",
     "lodash": "^4.17.23",
     "tslib": "^2.8.1",
     "undici-types": "^7.8.0"

--- a/src/http/http-operator.ts
+++ b/src/http/http-operator.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'eventemitter3';
 
 import {
   BodySerializerComponent,


### PR DESCRIPTION
## Summary

- Replaces `import { EventEmitter } from 'events'` in `HttpOperator` with `eventemitter3`, enabling utility-belt to be used in browser environments
- Adds `eventemitter3@^5.0.4` as a production dependency
- No public API changes — `on`, `emit`, and all other EventEmitter methods remain identical

## Test plan

- [x] All 254 existing tests pass
- [x] Build compiles cleanly
- [x] Lint passes (no-cache)

Closes [SEK-5](https://linear.app/sektek/issue/SEK-5)