### PR TITLE
feat: AbstractComponent extends EventEmitter

### DIFF
--- a/src/abstract-component.ts
+++ b/src/abstract-component.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'eventemitter3';
+
 import { LoggerProvider } from './types/logger-provider.js';
 import { NullLoggerProvider } from './null-logger-provider.js';
 
@@ -40,11 +42,12 @@ export type ComponentOptions<T = void> = {
  * @template T - The type of object passed to {@link AbstractComponent.logger}
  *               and forwarded to the logger provider. Defaults to `void`.
  */
-export abstract class AbstractComponent<T = void> {
+export abstract class AbstractComponent<T = void> extends EventEmitter {
   #name: string;
   #loggerProvider: LoggerProvider<T>;
 
   constructor(opts: ComponentOptions<T> = {}) {
+    super();
     this.#name = opts.name ?? generateName(this.constructor.name);
     this.#loggerProvider = opts.loggerProvider ?? new NullLoggerProvider();
   }


### PR DESCRIPTION
## Summary

- `AbstractComponent` now extends `EventEmitter` (eventemitter3), making all components and services browser-compatible event emitters out of the box
- `AbstractService` inherits this transitively
- `ComponentOptions` and constructor body are unchanged

## Why

Prerequisite for SEK-13 (cleanup synaptik's service abstractions): `AbstractEventComponent` in synaptik can extend `AbstractComponent` and gain EventEmitter capability without multiple inheritance.

## Test plan

- [x] All 254 tests pass
- [x] Build compiles cleanly
- [x] Lint passes (no-cache)

Part of SEK-13